### PR TITLE
Fix missing co-founder image imports

### DIFF
--- a/client/src/components/floating-team-section.tsx
+++ b/client/src/components/floating-team-section.tsx
@@ -16,6 +16,7 @@ import {
   Award
 } from "lucide-react";
 import founderImage from "@assets/Founder_1753708699510.jpg";
+import coFounderImage from "@assets/Co founder_1753673323506.jpg";
 import profAnongImage from "@assets/Prof Anong_1753743173746.jpg";
 
 const teamData = [

--- a/client/src/components/team-section.tsx
+++ b/client/src/components/team-section.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft, ChevronRight, Linkedin, Facebook, Mail } from "lucide-react";
 import founderImage from "@assets/Founder_1753708699510.jpg";
+import coFounderImage from "@assets/Co founder_1753673323506.jpg";
 import profAnongImage from "@assets/Prof Anong_1753743173746.jpg";
 
 const leadership = [


### PR DESCRIPTION
## Summary
- import co-founder image in FloatingTeamSection and TeamSection components
- rename co-founder asset file to have consistent extension

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689005eab7988324bf013b47f31244ff