### PR TITLE
Reduce section spacing on mobile

### DIFF
--- a/client/src/components/contact-section.tsx
+++ b/client/src/components/contact-section.tsx
@@ -3,9 +3,9 @@ import { MapPin, Mail, Phone } from "lucide-react";
 
 export default function ContactSection() {
   return (
-    <section id="contact" className="bg-white py-16">
+    <section id="contact" className="bg-white py-8 md:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Contact Us</h2>
           <p className="text-lg text-gray-600">Have questions? Reach out:</p>
         </div>

--- a/client/src/components/floating-gallery-section.tsx
+++ b/client/src/components/floating-gallery-section.tsx
@@ -146,9 +146,9 @@ export default function FloatingGallerySection() {
   const currentGalleryData = galleryData[currentGallery];
 
   return (
-    <section id="gallery" className="bg-gradient-to-br from-gray-50 to-gray-100 py-20 overflow-hidden">
+    <section id="gallery" className="bg-gradient-to-br from-gray-50 to-gray-100 py-10 md:py-20 overflow-hidden">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
+      <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Gallery</h2>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
             Capturing moments of learning, collaboration, and achievement
@@ -195,7 +195,7 @@ export default function FloatingGallerySection() {
               className="cursor-grab active:cursor-grabbing"
             >
               {/* Gallery Header */}
-              <div className="text-center mb-12">
+              <div className="text-center mb-8 md:mb-12">
                 <div className={`inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-r ${currentGalleryData.color} text-white text-3xl mb-6 shadow-xl`}>
                   <currentGalleryData.icon />
                 </div>

--- a/client/src/components/floating-programs-section.tsx
+++ b/client/src/components/floating-programs-section.tsx
@@ -195,9 +195,9 @@ export default function FloatingProgramsSection() {
   const currentProgram = programSections[currentSection];
 
   return (
-    <section id="programs" className="bg-gradient-to-br from-gray-50 to-gray-100 py-20 overflow-hidden">
+    <section id="programs" className="bg-gradient-to-br from-gray-50 to-gray-100 py-10 md:py-20 overflow-hidden">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
+          <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Explore Our Programs</h2>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
             Comprehensive learning paths designed to take you from beginner to professional
@@ -244,7 +244,7 @@ export default function FloatingProgramsSection() {
               className="cursor-grab active:cursor-grabbing"
             >
               {/* Section Header */}
-              <div className="text-center mb-12">
+            <div className="text-center mb-8 md:mb-12">
                 <div className={`inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-r ${currentProgram.color} text-white text-3xl mb-6 shadow-xl`}>
                   <currentProgram.icon />
                 </div>

--- a/client/src/components/floating-projects-section.tsx
+++ b/client/src/components/floating-projects-section.tsx
@@ -183,9 +183,9 @@ export default function FloatingProjectsSection() {
   };
 
   return (
-    <section id="projects" className="bg-gradient-to-br from-gray-50 to-gray-100 py-20 overflow-hidden">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
+      <section id="projects" className="bg-gradient-to-br from-gray-50 to-gray-100 py-10 md:py-20 overflow-hidden">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Student Projects</h2>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
             Real-world applications built by our talented participants
@@ -232,7 +232,7 @@ export default function FloatingProjectsSection() {
               className="cursor-grab active:cursor-grabbing"
             >
               {/* Category Header */}
-              <div className="text-center mb-12">
+              <div className="text-center mb-8 md:mb-12">
                 <div className={`inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-r ${currentCategoryData.color} text-white text-3xl mb-6 shadow-xl`}>
                   <currentCategoryData.icon />
                 </div>

--- a/client/src/components/floating-team-section.tsx
+++ b/client/src/components/floating-team-section.tsx
@@ -156,9 +156,9 @@ export default function FloatingTeamSection() {
   const currentTeamData = teamData[currentTeam];
 
   return (
-    <section id="team" className="bg-gradient-to-br from-gray-50 to-gray-100 py-20 overflow-hidden">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
+    <section id="team" className="bg-gradient-to-br from-gray-50 to-gray-100 py-10 md:py-20 overflow-hidden">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Meet Our Team</h2>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
             Dedicated professionals committed to your success
@@ -205,7 +205,7 @@ export default function FloatingTeamSection() {
               className="cursor-grab active:cursor-grabbing"
             >
               {/* Team Header */}
-              <div className="text-center mb-12">
+              <div className="text-center mb-8 md:mb-12">
                 <div className={`inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-r ${currentTeamData.color} text-white text-3xl mb-6 shadow-xl`}>
                   <currentTeamData.icon />
                 </div>

--- a/client/src/components/floating-testimonials-section.tsx
+++ b/client/src/components/floating-testimonials-section.tsx
@@ -178,9 +178,9 @@ export default function FloatingTestimonialsSection() {
   };
 
   return (
-    <section id="testimonials" className="bg-gradient-to-br from-gray-50 to-gray-100 py-20 overflow-hidden">
+    <section id="testimonials" className="bg-gradient-to-br from-gray-50 to-gray-100 py-10 md:py-20 overflow-hidden">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
+        <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Alumni Voices</h2>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
             Success stories and experiences from our amazing community
@@ -236,7 +236,7 @@ export default function FloatingTestimonialsSection() {
               className="cursor-grab active:cursor-grabbing"
             >
               {/* Category Header */}
-              <div className="text-center mb-12">
+              <div className="text-center mb-8 md:mb-12">
                 <div className={`inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-r ${currentCategoryData.color} text-white text-3xl mb-6 shadow-xl`}>
                   <currentCategoryData.icon />
                 </div>
@@ -319,7 +319,7 @@ export default function FloatingTestimonialsSection() {
                       })()}
                     </motion.div>
                   ) : (
-                    <div className="text-center py-12">
+                    <div className="text-center py-8 md:py-12">
                       <div className="bg-white rounded-lg shadow-lg p-8 max-w-md mx-auto">
                         <MessageSquare className="w-16 h-16 text-gray-400 mx-auto mb-4" />
                         <h3 className="text-xl font-semibold text-gray-900 mb-2">No Stories Yet</h3>

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
   };
 
   return (
-    <footer className="bg-gray-900 text-white py-12">
+    <footer className="bg-gray-900 text-white py-8 md:py-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid md:grid-cols-4 gap-8">
           <div className="col-span-2">

--- a/client/src/components/gallery-section.tsx
+++ b/client/src/components/gallery-section.tsx
@@ -89,9 +89,9 @@ export default function GallerySection() {
   };
 
   return (
-    <section id="gallery" className="bg-gray-50 py-16">
+    <section id="gallery" className="bg-gray-50 py-8 md:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Gallery</h2>
           <p className="text-lg text-gray-600">A selection of photos from past camps and hands-on workshops</p>
         </div>

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -21,7 +21,7 @@ export default function HeroSection() {
         <div className="absolute inset-0 bg-gradient-to-br from-primary/60 to-blue-800/70"></div>
       </div>
       
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20 lg:py-24">
+      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16 lg:py-24">
         <div className="text-center">
           <motion.h1 
             initial={{ opacity: 0, y: 30 }}

--- a/client/src/components/projects-section.tsx
+++ b/client/src/components/projects-section.tsx
@@ -28,9 +28,9 @@ const projects = [
 
 export default function ProjectsSection() {
   return (
-    <section id="projects" className="bg-white py-16">
+    <section id="projects" className="bg-white py-8 md:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Capstone Projects</h2>
           <p className="text-lg text-gray-600">Real-world applications developed by our participants</p>
         </div>

--- a/client/src/components/registration-form.tsx
+++ b/client/src/components/registration-form.tsx
@@ -91,7 +91,7 @@ export default function RegistrationForm() {
 
   if (isSubmitted) {
     return (
-      <section id="registration" className="bg-white py-16">
+      <section id="registration" className="bg-white py-8 md:py-16">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <Card className="p-8">
@@ -113,9 +113,9 @@ export default function RegistrationForm() {
   }
 
   return (
-    <section id="registration" className="bg-white py-16">
+    <section id="registration" className="bg-white py-8 md:py-16">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Register Now</h2>
           <p className="text-lg text-gray-600">
             Participation is free but space is limited. Please register before Application Deadline.

--- a/client/src/components/team-section.tsx
+++ b/client/src/components/team-section.tsx
@@ -127,9 +127,9 @@ export default function TeamSection() {
   };
 
   return (
-    <section id="team" className="bg-gray-50 py-16">
+    <section id="team" className="bg-gray-50 py-8 md:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Meet Our Team</h2>
           <p className="text-lg text-gray-600">Dedicated professionals committed to your success</p>
         </div>

--- a/client/src/components/testimonials-display.tsx
+++ b/client/src/components/testimonials-display.tsx
@@ -46,7 +46,7 @@ export function TestimonialsDisplay({ limit, showTitle = true }: TestimonialsDis
 
   if (testimonials.length === 0) {
     return (
-      <div className="text-center py-12">
+      <div className="text-center py-8 md:py-12">
         <Quote className="w-16 h-16 text-gray-300 mx-auto mb-4" />
         <h3 className="text-xl font-semibold text-gray-600 mb-2">No testimonials yet</h3>
         <p className="text-gray-500">Be the first alumni to share your experience!</p>

--- a/client/src/components/testimonials-section.tsx
+++ b/client/src/components/testimonials-section.tsx
@@ -27,9 +27,9 @@ const staticTestimonials = [
 
 export default function TestimonialsSection() {
   return (
-    <section id="testimonials" className="bg-gray-50 py-16">
+    <section id="testimonials" className="bg-gray-50 py-8 md:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Alumni Voices</h2>
           <p className="text-lg text-gray-600 mb-6">Hear from our successful graduates and share your own story</p>
           
@@ -40,13 +40,13 @@ export default function TestimonialsSection() {
         </div>
 
         {/* Dynamic Testimonials from Database */}
-        <div className="mb-12">
+        <div className="mb-8 md:mb-12">
           <TestimonialsDisplay showTitle={false} />
         </div>
 
         {/* Static Testimonials (will be replaced as more alumni submit) */}
-        <div className="border-t border-gray-200 pt-12">
-          <div className="text-center mb-8">
+        <div className="border-t border-gray-200 pt-8 md:pt-12">
+          <div className="text-center mb-6 md:mb-8">
             <h3 className="text-xl font-semibold text-gray-800 mb-2">Featured Stories</h3>
             <p className="text-gray-600">Highlights from our 2024 graduates</p>
           </div>

--- a/client/src/components/what-you-learn.tsx
+++ b/client/src/components/what-you-learn.tsx
@@ -81,9 +81,9 @@ export default function WhatYouLearn() {
   };
 
   return (
-    <section id="learn" className="bg-white py-16">
+    <section id="learn" className="bg-white py-8 md:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">What You'll Learn</h2>
           <p className="text-lg text-gray-600">Comprehensive curriculum designed for practical skills development</p>
         </div>

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -155,7 +155,7 @@ export default function AdminPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <section className="bg-gradient-to-r from-primary to-blue-700 text-white py-12">
+      <section className="bg-gradient-to-r from-primary to-blue-700 text-white py-8 md:py-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <Settings className="w-12 h-12 mx-auto mb-4" />
           <h1 className="text-3xl md:text-4xl font-bold mb-2">Blog Administration</h1>
@@ -166,7 +166,7 @@ export default function AdminPage() {
       </section>
 
       {/* Admin Content */}
-      <section className="py-12">
+      <section className="py-8 md:py-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <Tabs defaultValue="pending" className="w-full">
             <TabsList className="grid w-full grid-cols-2 max-w-md mx-auto mb-8">
@@ -182,12 +182,12 @@ export default function AdminPage() {
 
             <TabsContent value="pending">
               {loadingUnapproved ? (
-                <div className="text-center py-12">
+                <div className="text-center py-8 md:py-12">
                   <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
                   <p className="mt-4 text-gray-600">Loading pending posts...</p>
                 </div>
               ) : unapprovedPosts.length === 0 ? (
-                <div className="text-center py-12">
+                <div className="text-center py-8 md:py-12">
                   <Check className="w-16 h-16 text-gray-300 mx-auto mb-4" />
                   <h3 className="text-xl font-semibold text-gray-900 mb-2">No Pending Posts</h3>
                   <p className="text-gray-600">
@@ -203,12 +203,12 @@ export default function AdminPage() {
 
             <TabsContent value="published">
               {loadingPublished ? (
-                <div className="text-center py-12">
+                <div className="text-center py-8 md:py-12">
                   <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
                   <p className="mt-4 text-gray-600">Loading published posts...</p>
                 </div>
               ) : publishedPosts.length === 0 ? (
-                <div className="text-center py-12">
+                <div className="text-center py-8 md:py-12">
                   <Settings className="w-16 h-16 text-gray-300 mx-auto mb-4" />
                   <h3 className="text-xl font-semibold text-gray-900 mb-2">No Published Posts</h3>
                   <p className="text-gray-600">

--- a/client/src/pages/blog-post.tsx
+++ b/client/src/pages/blog-post.tsx
@@ -35,7 +35,7 @@ export default function BlogPostPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 py-12">
+      <div className="min-h-screen bg-gray-50 py-8 md:py-12">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary mx-auto"></div>
@@ -48,7 +48,7 @@ export default function BlogPostPage() {
 
   if (error || !blogPost) {
     return (
-      <div className="min-h-screen bg-gray-50 py-12">
+      <div className="min-h-screen bg-gray-50 py-8 md:py-12">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="text-3xl font-bold text-gray-900 mb-4">Blog Post Not Found</h1>
           <p className="text-gray-600 mb-8">The blog post you're looking for doesn't exist or has been removed.</p>
@@ -107,7 +107,7 @@ export default function BlogPostPage() {
       )}
 
       {/* Article */}
-      <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
         <header className="mb-8">
           {blogPost.category && (
             <Badge variant="secondary" className="mb-4">

--- a/client/src/pages/blog.tsx
+++ b/client/src/pages/blog.tsx
@@ -36,7 +36,7 @@ export default function BlogPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 py-12">
+      <div className="min-h-screen bg-gray-50 py-8 md:py-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary mx-auto"></div>
@@ -50,7 +50,7 @@ export default function BlogPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <section className="bg-gradient-to-r from-primary to-blue-700 text-white py-20">
+      <section className="bg-gradient-to-r from-primary to-blue-700 text-white py-10 md:py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <BookOpen className="w-16 h-16 mx-auto mb-6" />
           <h1 className="text-4xl md:text-5xl font-bold mb-4">UBa Tech Camp Blog</h1>
@@ -61,7 +61,7 @@ export default function BlogPage() {
       </section>
 
       {/* Blog Content */}
-      <section className="py-16">
+      <section className="py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
             <TabsList className="grid w-full grid-cols-2 max-w-md mx-auto mb-8">
@@ -77,7 +77,7 @@ export default function BlogPage() {
 
             <TabsContent value="posts" className="mt-0">
           {blogPosts.length === 0 ? (
-            <div className="text-center py-12">
+            <div className="text-center py-8 md:py-12">
               <BookOpen className="w-24 h-24 text-gray-300 mx-auto mb-4" />
               <h3 className="text-2xl font-semibold text-gray-900 mb-2">No Blog Posts Yet</h3>
               <p className="text-gray-600 max-w-md mx-auto">

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -22,7 +22,7 @@ const sectionsData = [
     title: "Registration Information",
     icon: Users,
     component: (
-      <div className="text-center py-12">
+      <div className="text-center py-8 md:py-12">
         <h3 className="text-2xl font-bold text-gray-900 mb-4">Ready to Join UBa Tech Camp 2025?</h3>
         <p className="text-gray-600 mb-6">All the interactive sections above showcase what awaits you. Register below to secure your spot!</p>
         <Button 
@@ -60,9 +60,9 @@ export default function Home() {
       <HeroSection />
 
       {/* Impact Section - Moved Up */}
-      <section className="bg-white py-16">
+      <section className="bg-white py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
+          <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Our Impact</h2>
           </div>
           
@@ -102,9 +102,9 @@ export default function Home() {
       </section>
 
       {/* Partnership Section */}
-      <section className="bg-gray-50 py-16">
+      <section className="bg-gray-50 py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
+          <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Official Partnership</h2>
             <Card className="p-8 max-w-2xl mx-auto hover:shadow-lg transition-shadow duration-300">
               <Handshake className="text-primary text-4xl mb-4 mx-auto" />
@@ -134,10 +134,10 @@ export default function Home() {
       <FloatingTestimonialsSection />
 
       {/* Registration Call-to-Action */}
-      <section className="bg-gradient-to-r from-blue-500 to-blue-700 py-16">
+      <section className="bg-gradient-to-r from-blue-500 to-blue-700 py-8 md:py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold text-white mb-4">Ready to Join UBa Tech Camp 2025?</h2>
-          <p className="text-xl text-blue-100 mb-8">All the interactive sections above showcase what awaits you. Register below to secure your spot!</p>
+          <p className="text-xl text-blue-100 mb-6 md:mb-8">All the interactive sections above showcase what awaits you. Register below to secure your spot!</p>
           <Button 
             onClick={() => document.getElementById('registration')?.scrollIntoView({ behavior: 'smooth' })}
             size="lg"
@@ -151,7 +151,7 @@ export default function Home() {
 
 
       {/* Certification */}
-      <section className="bg-primary text-white py-16">
+      <section className="bg-primary text-white py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold mb-4">Official Certification</h2>
           <p className="text-xl text-blue-100 mb-6">Receive certificates recognized by the University of Bamenda</p>
@@ -165,9 +165,9 @@ export default function Home() {
       <RegistrationForm />
 
       {/* Alumni Network */}
-      <section id="alumni-network" className="bg-white py-16">
+      <section id="alumni-network" className="bg-white py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
+          <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Alumni Network</h2>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Join our growing community of tech professionals. Our alumni work at leading companies worldwide and continue to support current students through mentorship and career guidance.
@@ -289,9 +289,9 @@ export default function Home() {
       </section>
 
       {/* Get Involved */}
-      <section id="get-involved" className="bg-gray-50 py-16">
+      <section id="get-involved" className="bg-gray-50 py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
+          <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Get Involved</h2>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               We welcome partnerships with companies, NGOs, and individuals who share our mission. Whether you offer funding, guest lectures, equipment, or mentorship, your support helps shape Cameroon's next generation of tech leaders.
@@ -309,9 +309,9 @@ export default function Home() {
       </section>
 
       {/* FAQ */}
-      <section className="bg-white py-16">
+      <section className="bg-white py-8 md:py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
+          <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Frequently Asked Questions</h2>
           </div>
           
@@ -340,10 +340,10 @@ export default function Home() {
       </section>
 
       {/* Newsletter */}
-      <section className="bg-primary text-white py-16">
+      <section className="bg-primary text-white py-8 md:py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold mb-4">Stay Connected</h2>
-          <p className="text-xl text-blue-100 mb-8">Subscribe to our newsletter for camp updates, resources, and future event announcements.</p>
+          <p className="text-xl text-blue-100 mb-6 md:mb-8">Subscribe to our newsletter for camp updates, resources, and future event announcements.</p>
           
           <div className="max-w-md mx-auto">
             <div className="flex">


### PR DESCRIPTION
## Summary
- shrink vertical padding on home page sections for better mobile spacing
- tighten gaps in floating program and content sections on small screens
- adjust footer spacing to match responsive layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68905f78d5408324aa5697349fe36dc6