### PR TITLE
chore: remove section captions

### DIFF
--- a/client/src/components/contact-section.tsx
+++ b/client/src/components/contact-section.tsx
@@ -7,7 +7,6 @@ export default function ContactSection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Contact Us</h2>
-          <p className="text-lg text-gray-600">Have questions? Reach out:</p>
         </div>
         
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 max-w-4xl mx-auto">

--- a/client/src/components/floating-gallery-section.tsx
+++ b/client/src/components/floating-gallery-section.tsx
@@ -150,9 +150,6 @@ export default function FloatingGallerySection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Gallery</h2>
-          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Capturing moments of learning, collaboration, and achievement
-          </p>
         </div>
 
         {/* Gallery Navigation */}

--- a/client/src/components/floating-programs-section.tsx
+++ b/client/src/components/floating-programs-section.tsx
@@ -199,9 +199,6 @@ export default function FloatingProgramsSection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Explore Our Programs</h2>
-          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Comprehensive learning paths designed to take you from beginner to professional
-          </p>
         </div>
 
         {/* Section Navigation */}

--- a/client/src/components/floating-projects-section.tsx
+++ b/client/src/components/floating-projects-section.tsx
@@ -187,9 +187,6 @@ export default function FloatingProjectsSection() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Student Projects</h2>
-          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Real-world applications built by our talented participants
-          </p>
         </div>
 
         {/* Category Navigation */}

--- a/client/src/components/floating-team-section.tsx
+++ b/client/src/components/floating-team-section.tsx
@@ -160,9 +160,6 @@ export default function FloatingTeamSection() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Meet Our Team</h2>
-          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Dedicated professionals committed to your success
-          </p>
         </div>
 
         {/* Team Navigation */}

--- a/client/src/components/floating-testimonials-section.tsx
+++ b/client/src/components/floating-testimonials-section.tsx
@@ -182,9 +182,6 @@ export default function FloatingTestimonialsSection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-16">
           <h2 className="text-4xl font-bold text-gray-900 mb-4">Alumni Voices</h2>
-          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Success stories and experiences from our amazing community
-          </p>
         </div>
 
         {/* Category Navigation */}

--- a/client/src/components/gallery-section.tsx
+++ b/client/src/components/gallery-section.tsx
@@ -93,7 +93,6 @@ export default function GallerySection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Gallery</h2>
-          <p className="text-lg text-gray-600">A selection of photos from past camps and hands-on workshops</p>
         </div>
         
         {/* Carousel Container */}

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -32,14 +32,6 @@ export default function HeroSection() {
             Welcome to UBa Tech Camp 2025
           </motion.h1>
           
-          <motion.p 
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.2 }}
-            className="text-lg sm:text-xl md:text-2xl mb-6 sm:mb-8 text-blue-100 px-2"
-          >
-            Empowering Youth with Digital Skills
-          </motion.p>
           
           <motion.div 
             initial={{ opacity: 0, y: 30 }}

--- a/client/src/components/projects-section.tsx
+++ b/client/src/components/projects-section.tsx
@@ -32,7 +32,6 @@ export default function ProjectsSection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Capstone Projects</h2>
-          <p className="text-lg text-gray-600">Real-world applications developed by our participants</p>
         </div>
         
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8">

--- a/client/src/components/registration-form.tsx
+++ b/client/src/components/registration-form.tsx
@@ -117,9 +117,6 @@ export default function RegistrationForm() {
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Register Now</h2>
-          <p className="text-lg text-gray-600">
-            Participation is free but space is limited. Please register before Application Deadline.
-          </p>
         </div>
         
         <Card className="p-8">

--- a/client/src/components/team-section.tsx
+++ b/client/src/components/team-section.tsx
@@ -131,7 +131,6 @@ export default function TeamSection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Meet Our Team</h2>
-          <p className="text-lg text-gray-600">Dedicated professionals committed to your success</p>
         </div>
 
         {/* Category Tabs */}

--- a/client/src/components/testimonials-section.tsx
+++ b/client/src/components/testimonials-section.tsx
@@ -31,8 +31,6 @@ export default function TestimonialsSection() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Alumni Voices</h2>
-          <p className="text-lg text-gray-600 mb-6">Hear from our successful graduates and share your own story</p>
-          
           {/* Call to Action for Alumni */}
           <div className="flex justify-center mb-8">
             <TestimonialForm />

--- a/client/src/components/what-you-learn.tsx
+++ b/client/src/components/what-you-learn.tsx
@@ -85,7 +85,6 @@ export default function WhatYouLearn() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8 md:mb-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">What You'll Learn</h2>
-          <p className="text-lg text-gray-600">Comprehensive curriculum designed for practical skills development</p>
         </div>
         
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -159,9 +159,6 @@ export default function AdminPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <Settings className="w-12 h-12 mx-auto mb-4" />
           <h1 className="text-3xl md:text-4xl font-bold mb-2">Blog Administration</h1>
-          <p className="text-xl text-blue-100">
-            Manage and approve blog post submissions
-          </p>
         </div>
       </section>
 

--- a/client/src/pages/blog.tsx
+++ b/client/src/pages/blog.tsx
@@ -54,9 +54,6 @@ export default function BlogPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <BookOpen className="w-16 h-16 mx-auto mb-6" />
           <h1 className="text-4xl md:text-5xl font-bold mb-4">UBa Tech Camp Blog</h1>
-          <p className="text-xl text-blue-100 max-w-2xl mx-auto">
-            Insights, stories, and updates from our tech education community
-          </p>
         </div>
       </section>
 

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -24,8 +24,7 @@ const sectionsData = [
     component: (
       <div className="text-center py-8 md:py-12">
         <h3 className="text-2xl font-bold text-gray-900 mb-4">Ready to Join UBa Tech Camp 2025?</h3>
-        <p className="text-gray-600 mb-6">All the interactive sections above showcase what awaits you. Register below to secure your spot!</p>
-        <Button 
+        <Button
           onClick={() => document.getElementById('registration')?.scrollIntoView({ behavior: 'smooth' })}
           className="bg-gradient-to-r from-blue-500 to-blue-700 hover:opacity-90"
         >
@@ -137,8 +136,7 @@ export default function Home() {
       <section className="bg-gradient-to-r from-blue-500 to-blue-700 py-8 md:py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold text-white mb-4">Ready to Join UBa Tech Camp 2025?</h2>
-          <p className="text-xl text-blue-100 mb-6 md:mb-8">All the interactive sections above showcase what awaits you. Register below to secure your spot!</p>
-          <Button 
+          <Button
             onClick={() => document.getElementById('registration')?.scrollIntoView({ behavior: 'smooth' })}
             size="lg"
             className="bg-white text-blue-600 hover:bg-gray-50 font-semibold px-8 py-3"
@@ -154,7 +152,6 @@ export default function Home() {
       <section className="bg-primary text-white py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold mb-4">Official Certification</h2>
-          <p className="text-xl text-blue-100 mb-6">Receive certificates recognized by the University of Bamenda</p>
           <Card className="bg-white bg-opacity-10 p-6 max-w-2xl mx-auto border-0">
             <Tag className="text-yellow-400 text-4xl mb-4 mx-auto" />
             <p className="text-lg">All participants receive official certificates from the University of Bamenda in partnership with the Directorate of Student Affairs, validating your new digital skills.</p>
@@ -169,9 +166,6 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Alumni Network</h2>
-            <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              Join our growing community of tech professionals. Our alumni work at leading companies worldwide and continue to support current students through mentorship and career guidance.
-            </p>
           </div>
           
           {/* Alumni by Faculty */}
@@ -293,12 +287,9 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Get Involved</h2>
-            <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              We welcome partnerships with companies, NGOs, and individuals who share our mission. Whether you offer funding, guest lectures, equipment, or mentorship, your support helps shape Cameroon's next generation of tech leaders.
-            </p>
             <div className="mt-8">
-              <a 
-                href="mailto:info@ubatechcamp.org" 
+              <a
+                href="mailto:info@ubatechcamp.org"
                 className="bg-primary hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg transition duration-300 inline-block"
               >
                 Partner With Us
@@ -343,8 +334,7 @@ export default function Home() {
       <section className="bg-primary text-white py-8 md:py-16">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold mb-4">Stay Connected</h2>
-          <p className="text-xl text-blue-100 mb-6 md:mb-8">Subscribe to our newsletter for camp updates, resources, and future event announcements.</p>
-          
+
           <div className="max-w-md mx-auto">
             <div className="flex">
               <input 


### PR DESCRIPTION
## Summary
- strip caption text from Explore Our Programs section and other homepage sections
- drop subheadings from gallery, team, project, testimonial, and contact components
- clean up captions in blog and admin page headers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890638105b88324bfec2385faf3fd4e