### PR TITLE
Move impact photo to hero and adjust layout

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -1,118 +1,112 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Calendar, MapPin, X } from "lucide-react";
+import { Calendar, MapPin } from "lucide-react";
 import { motion } from "framer-motion";
-import heroImage from "@assets/use on hero_1753709100915.png";
-import computerLiteracyBg from "@assets/computer literacy photo_1753673323506.png";
+import heroBg from "@assets/use on hero_1753673323493.png";
 
 export default function HeroSection() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
-    <section id="home" className="relative bg-gradient-to-br from-primary to-blue-800 text-white overflow-hidden">
+    <section id="home" className="relative text-white overflow-hidden">
       {/* Background Image */}
-      <div className="absolute inset-0 z-0">
-        <img 
-          src={computerLiteracyBg}
-          alt="UBa Tech Camp Students Learning Computer Literacy"
-          className="w-full h-full object-cover opacity-70"
+      <div className="absolute inset-0">
+        <img
+          src={heroBg}
+          alt="UBa Tech Camp students engaging in tech activities"
+          className="w-full h-full object-cover"
         />
-        <div className="absolute inset-0 bg-gradient-to-br from-primary/60 to-blue-800/70"></div>
+        <div className="absolute inset-0 bg-gradient-to-t from-primary/90 via-primary/50 to-transparent"></div>
       </div>
-      
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16 lg:py-24">
-        <div className="text-center">
-          <motion.h1 
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-4 sm:mb-6 leading-tight"
-          >
-            Welcome to UBa Tech Camp 2025
-          </motion.h1>
-          
-          
-          <motion.div 
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.4 }}
-            className="mb-6 sm:mb-8 text-base sm:text-lg space-y-2 sm:space-y-0"
-          >
-            <div className="flex flex-col sm:flex-row items-center justify-center sm:space-x-8 space-y-2 sm:space-y-0">
-              <p className="flex items-center">
-                <Calendar className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-                <span className="text-sm sm:text-base">10 July – 10 August 2025</span>
-              </p>
-              <p className="flex items-center">
-                <MapPin className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
-                <span className="text-sm sm:text-base">University of Bamenda Campus</span>
-              </p>
-            </div>
-          </motion.div>
-          
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.6 }}
-          >
-            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-              <DialogTrigger asChild>
+
+      <div className="relative z-10 flex flex-col justify-end items-center h-[80vh] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-10 text-center">
+        <motion.h1
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-4 sm:mb-6 leading-tight"
+        >
+          Welcome to UBa Tech Camp 2025
+        </motion.h1>
+
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 0.4 }}
+          className="mb-6 sm:mb-8 text-base sm:text-lg space-y-2 sm:space-y-0"
+        >
+          <div className="flex flex-col sm:flex-row items-center justify-center sm:space-x-8 space-y-2 sm:space-y-0">
+            <p className="flex items-center">
+              <Calendar className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+              <span className="text-sm sm:text-base">10 July – 10 August 2025</span>
+            </p>
+            <p className="flex items-center">
+              <MapPin className="mr-2 h-4 w-4 sm:h-5 sm:w-5" />
+              <span className="text-sm sm:text-base">University of Bamenda Campus</span>
+            </p>
+          </div>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 0.6 }}
+        >
+          <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+            <DialogTrigger asChild>
+              <Button
+                className="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-3 px-6 sm:py-4 sm:px-8 rounded-lg text-base sm:text-lg transition duration-300 transform hover:scale-105"
+                size="lg"
+              >
+                Learn More
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle className="text-2xl font-bold text-primary mb-4">About UBa Tech Camp</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4 text-gray-600 leading-relaxed">
+                <p className="text-lg">
+                  UBa Tech Camp is a transformative digital skills programme hosted at the University of Bamenda.
+                  It is designed to empower students with practical, in-demand tech competencies that are essential
+                  in today's digital economy. Founded by Jam Ransom, the camp provides free hands-on training in
+                  areas such as basic computer skills, data analysis, programming, and essential digital tools.
+                </p>
+
+                <p className="text-lg">
+                  At its core, UBa Tech Camp is about empowerment, innovation, and career readiness. The programme
+                  welcomes students from all faculties and backgrounds, creating an inclusive environment where they
+                  can gain critical tech skills, boost their confidence, and apply their knowledge to real-world challenges.
+                </p>
+
+                <p className="text-lg font-medium text-primary">
+                  UBa Tech Camp is not just a training programme, it is a movement that is shaping the next generation
+                  of digital leaders in Cameroon and beyond. It inspires students to think big, learn fast, and lead
+                  change through technology.
+                </p>
+              </div>
+
+              <div className="mt-8 text-center">
                 <Button
-                  className="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-3 px-6 sm:py-4 sm:px-8 rounded-lg text-base sm:text-lg transition duration-300 transform hover:scale-105"
-                  size="lg"
+                  onClick={() => {
+                    setIsDialogOpen(false);
+                    setTimeout(() => {
+                      const element = document.getElementById('register');
+                      if (element) {
+                        element.scrollIntoView({ behavior: 'smooth' });
+                      }
+                    }, 300);
+                  }}
+                  className="bg-primary hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg text-lg transition duration-300"
                 >
-                  Learn More
+                  Join the Movement
                 </Button>
-              </DialogTrigger>
-              <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
-                <DialogHeader>
-                  <DialogTitle className="text-2xl font-bold text-primary mb-4">About UBa Tech Camp</DialogTitle>
-                </DialogHeader>
-                <div className="space-y-4 text-gray-600 leading-relaxed">
-                  <p className="text-lg">
-                    UBa Tech Camp is a transformative digital skills programme hosted at the University of Bamenda. 
-                    It is designed to empower students with practical, in-demand tech competencies that are essential 
-                    in today's digital economy. Founded by Jam Ransom, the camp provides free hands-on training in 
-                    areas such as basic computer skills, data analysis, programming, and essential digital tools.
-                  </p>
-                  
-                  <p className="text-lg">
-                    At its core, UBa Tech Camp is about empowerment, innovation, and career readiness. The programme 
-                    welcomes students from all faculties and backgrounds, creating an inclusive environment where they 
-                    can gain critical tech skills, boost their confidence, and apply their knowledge to real-world challenges.
-                  </p>
-                  
-                  <p className="text-lg font-medium text-primary">
-                    UBa Tech Camp is not just a training programme, it is a movement that is shaping the next generation 
-                    of digital leaders in Cameroon and beyond. It inspires students to think big, learn fast, and lead 
-                    change through technology.
-                  </p>
-                </div>
-                
-                <div className="mt-8 text-center">
-                  <Button
-                    onClick={() => {
-                      setIsDialogOpen(false);
-                      setTimeout(() => {
-                        const element = document.getElementById('register');
-                        if (element) {
-                          element.scrollIntoView({ behavior: 'smooth' });
-                        }
-                      }, 300);
-                    }}
-                    className="bg-primary hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg text-lg transition duration-300"
-                  >
-                    Join the Movement
-                  </Button>
-                </div>
-              </DialogContent>
-            </Dialog>
-          </motion.div>
-        </div>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </motion.div>
       </div>
-
-
     </section>
   );
 }

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -14,7 +14,6 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { motion, AnimatePresence } from "framer-motion";
 import { Handshake, Tag, Users, Award, ChevronDown, ChevronUp, BookOpen, Trophy, MessageSquare, Star } from "lucide-react";
-import impactImage from "@assets/use on hero_1753673323493.png";
 
 const sectionsData = [
   {
@@ -58,44 +57,34 @@ export default function Home() {
       <Navigation />
       <HeroSection />
 
-      {/* Impact Section - Moved Up */}
+      {/* Impact Section - Image moved to hero */}
       <section className="bg-white py-8 md:py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-8 md:mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Our Impact</h2>
           </div>
-          
-          <div className="grid lg:grid-cols-2 gap-8 items-center">
-            <div className="order-2 lg:order-1">
-              <img 
-                src={impactImage}
-                alt="UBa Tech Camp students actively learning in computer lab with laptops and hands-on training"
-                className="w-full h-96 object-cover rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300"
-              />
-            </div>
-            
-            <div className="order-1 lg:order-2">
-              <Card className="bg-gradient-to-br from-primary to-blue-800 text-white p-8 hover:shadow-xl transition-all duration-300">
-                <div className="grid grid-cols-2 gap-6 text-center">
-                  <div className="border-r border-blue-300 pr-4">
-                    <div className="text-3xl md:text-4xl font-bold mb-2">200+</div>
-                    <p className="text-sm md:text-base text-blue-100">Participants trained from 1st and 2nd Edition</p>
-                  </div>
-                  <div className="pl-4">
-                    <div className="text-3xl md:text-4xl font-bold mb-2">6</div>
-                    <p className="text-sm md:text-base text-blue-100">Core technical skills taught in each camp</p>
-                  </div>
-                  <div className="border-r border-blue-300 pr-4">
-                    <div className="text-3xl md:text-4xl font-bold mb-2">6</div>
-                    <p className="text-sm md:text-base text-blue-100">Schools participating in the program</p>
-                  </div>
-                  <div className="pl-4">
-                    <div className="text-3xl md:text-4xl font-bold mb-2">6</div>
-                    <p className="text-sm md:text-base text-blue-100">University faculties represented</p>
-                  </div>
+
+          <div className="flex justify-center">
+            <Card className="bg-gradient-to-br from-primary to-blue-800 text-white p-8 hover:shadow-xl transition-all duration-300">
+              <div className="grid grid-cols-2 gap-6 text-center">
+                <div className="border-r border-blue-300 pr-4">
+                  <div className="text-3xl md:text-4xl font-bold mb-2">200+</div>
+                  <p className="text-sm md:text-base text-blue-100">Participants trained from 1st and 2nd Edition</p>
                 </div>
-              </Card>
-            </div>
+                <div className="pl-4">
+                  <div className="text-3xl md:text-4xl font-bold mb-2">6</div>
+                  <p className="text-sm md:text-base text-blue-100">Core technical skills taught in each camp</p>
+                </div>
+                <div className="border-r border-blue-300 pr-4">
+                  <div className="text-3xl md:text-4xl font-bold mb-2">6</div>
+                  <p className="text-sm md:text-base text-blue-100">Schools participating in the program</p>
+                </div>
+                <div className="pl-4">
+                  <div className="text-3xl md:text-4xl font-bold mb-2">6</div>
+                  <p className="text-sm md:text-base text-blue-100">University faculties represented</p>
+                </div>
+              </div>
+            </Card>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Place former impact photo in hero welcome section with blue gradient overlay
- Remove impact image from impact section, leaving centered stats card

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68908f47a1a08324af783694ca48a192