### PR TITLE
feat: update hero section call to action

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -35,7 +35,7 @@ export default function HeroSection() {
           transition={{ duration: 0.8, delay: 0.4 }}
           className="mb-6 sm:mb-8 text-base sm:text-lg"
         >
-          Tech for All
+          Empowering youths with digital skills
         </motion.p>
 
         <motion.div
@@ -46,8 +46,7 @@ export default function HeroSection() {
           <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
             <DialogTrigger asChild>
               <Button
-                className="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-3 px-6 sm:py-4 sm:px-8 rounded-lg text-base sm:text-lg transition duration-300 transform hover:scale-105"
-                size="lg"
+                className="bg-primary hover:bg-primary/90 text-white font-semibold h-auto py-2 px-4 sm:py-3 sm:px-6 rounded-lg text-sm sm:text-base transition duration-300 transform hover:scale-105"
               >
                 Learn More
               </Button>


### PR DESCRIPTION
## Summary
- restyled Hero "Learn More" button to use primary palette and a smaller size
- refreshed tagline to "Empowering youths with digital skills"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689097f3994c83249d02db8280abcde3