### PR TITLE
feat: change menu button click color to blue

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -102,6 +102,9 @@ export default function Navigation() {
               variant="ghost"
               size="sm"
               onClick={() => setIsOpen(!isOpen)}
+              className={`${
+                isOpen ? "bg-primary text-primary-foreground" : ""
+              } hover:bg-primary hover:text-primary-foreground active:bg-primary active:text-primary-foreground`}
             >
               {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
             </Button>


### PR DESCRIPTION
## Summary
- use primary blue color for mobile menu toggle instead of yellow accent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68909c8f47308324829a235fac765d76