### PR TITLE
Rename programs section to Training programs

### DIFF
--- a/client/src/components/floating-programs-section.tsx
+++ b/client/src/components/floating-programs-section.tsx
@@ -195,10 +195,13 @@ export default function FloatingProgramsSection() {
   const currentProgram = programSections[currentSection];
 
   return (
-    <section id="programs" className="bg-gradient-to-br from-gray-50 to-gray-100 py-10 md:py-20 overflow-hidden">
+    <section
+      id="programs"
+      className="bg-gradient-to-br from-gray-50 to-gray-100 -mt-6 md:-mt-12 pt-4 md:pt-8 pb-10 md:pb-20 overflow-hidden"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-8 md:mb-16">
-          <h2 className="text-4xl font-bold text-gray-900 mb-4">Explore Our Programs</h2>
+        <div className="text-center mb-8 md:mb-16">
+          <h2 className="text-3xl font-bold text-gray-900 mb-4">Training programs</h2>
         </div>
 
         {/* Section Navigation */}

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -122,7 +122,7 @@ export default function Navigation() {
                 onClick={() => scrollToSection('programs')}
                 className="text-gray-600 hover:text-primary block px-3 py-3 rounded-md text-base font-medium w-full text-left border-b border-gray-100"
               >
-                Explore Our Programs
+                Training programs
               </button>
               <button 
                 onClick={() => scrollToSection('team')}


### PR DESCRIPTION
## Summary
- rename "Explore Our Programs" section to "Training programs"
- match heading size with Official Partnership and tighten spacing
- update navigation link text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890a49012d08324943c10487823579a