### PR TITLE
Unify training program colors

### DIFF
--- a/client/src/components/floating-programs-section.tsx
+++ b/client/src/components/floating-programs-section.tsx
@@ -57,9 +57,9 @@ const programSections = [
   },
   {
     id: "programming",
-    title: "Programming & Development", 
+    title: "Programming & Development",
     description: "Build real applications with modern programming languages",
-    color: "from-green-500 to-green-700",
+    color: "from-blue-500 to-blue-700",
     icon: Code,
     duration: "Week 3-4",
     courses: [
@@ -95,7 +95,7 @@ const programSections = [
     id: "data-analysis",
     title: "Data Analysis & Research",
     description: "Transform raw data into meaningful insights",
-    color: "from-purple-500 to-purple-700", 
+    color: "from-blue-500 to-blue-700",
     icon: BarChart,
     duration: "Week 5-6",
     courses: [
@@ -131,7 +131,7 @@ const programSections = [
     id: "collaboration",
     title: "Professional Skills",
     description: "Essential soft skills for the modern workplace",
-    color: "from-orange-500 to-orange-700",
+    color: "from-blue-500 to-blue-700",
     icon: Users,
     duration: "Week 7-8",
     courses: [


### PR DESCRIPTION
## Summary
- align all training program subsections with the blue gradient used by Computer Literacy for consistent styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890a73b6acc8324b8c20731a6c2271c