### PR TITLE
feat: add spacing after hero section

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -8,7 +8,7 @@ export default function HeroSection() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
-    <section id="home" className="relative text-white overflow-hidden">
+    <section id="home" className="relative text-white overflow-hidden mb-8 md:mb-16">
       {/* Background Image */}
       <div className="absolute inset-0">
         <img


### PR DESCRIPTION
## Summary
- increase gap between hero section and following content for clearer separation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6890ade214b4832484d5d80ad4fe5a45