### PR TITLE
Reorder training programs and update computer literacy details

### DIFF
--- a/client/src/components/floating-programs-section.tsx
+++ b/client/src/components/floating-programs-section.tsx
@@ -25,6 +25,7 @@ const programSections = [
         title: "Computer Literacy",
         description: "Essential digital skills everyone needs",
         details: [
+          "Microsoft office programs",
           "File management and organization",
           "Digital communication tools",
           "Basic troubleshooting",
@@ -153,9 +154,17 @@ const programSections = [
 ];
 
 export default function FloatingProgramsSection() {
-  const allCourses = programSections.flatMap((section) =>
+  const unorderedCourses = programSections.flatMap((section) =>
     section.courses.map((course) => ({ ...course, color: section.color }))
   );
+
+  const prioritized = ["computer-literacy", "spss"];
+  const allCourses = [
+    ...prioritized.map((id) =>
+      unorderedCourses.find((course) => course.id === id)!
+    ),
+    ...unorderedCourses.filter((course) => !prioritized.includes(course.id)),
+  ];
 
   return (
     <section


### PR DESCRIPTION
## Summary
- Prioritize Computer Literacy and Statistical Analysis in training program listing
- Highlight Microsoft Office programs as the first Computer Literacy bullet

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6890bf15063c83248bec2eb00286d3ca