### PR TITLE
feat: add navigation to blog pages

### DIFF
--- a/client/src/pages/blog-post.tsx
+++ b/client/src/pages/blog-post.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import Navigation from "@/components/navigation";
 import { useRoute, Link } from "wouter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -83,6 +84,7 @@ export default function BlogPostPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <Navigation />
       {/* Header */}
       <div className="bg-white border-b">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4">

--- a/client/src/pages/blog.tsx
+++ b/client/src/pages/blog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Navigation from "@/components/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -49,6 +50,7 @@ export default function BlogPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <Navigation />
       {/* Header */}
       <section className="bg-gradient-to-r from-primary to-blue-700 text-white py-10 md:py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">


### PR DESCRIPTION
## Summary
- show site navigation header on blog listing and individual post pages for consistent navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6891594510888324a1280b218a359079