### PR TITLE
Restore detailed team cards

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import Navigation from "@/components/navigation";
 import HeroSection from "@/components/hero-section";
 import FloatingProgramsSection from "@/components/floating-programs-section";
-import FloatingTeamSection from "@/components/floating-team-section";
+import TeamSection from "@/components/team-section";
 import FloatingGallerySection from "@/components/floating-gallery-section";
 import FloatingProjectsSection from "@/components/floating-projects-section";
 import FloatingTestimonialsSection from "@/components/floating-testimonials-section";
@@ -105,8 +105,8 @@ export default function Home() {
       {/* Interactive Floating Programs Section */}
       <FloatingProgramsSection />
 
-      {/* Interactive Floating Team Section */}
-      <FloatingTeamSection />
+      {/* Team Section */}
+      <TeamSection />
 
       {/* Interactive Floating Gallery Section */}
       <FloatingGallerySection />


### PR DESCRIPTION
## Summary
- Replace image-only team section with full `TeamSection` cards displaying name, role and social links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68915d2d663c832488a68a97a63408f7