### PR TITLE
Align registration route path

### DIFF
--- a/client/src/components/registration-form.tsx
+++ b/client/src/components/registration-form.tsx
@@ -43,7 +43,7 @@ export default function RegistrationForm() {
 
   const registrationMutation = useMutation({
     mutationFn: async (data: InsertRegistration) => {
-      const response = await apiRequest("POST", "/api/registrations", data);
+      const response = await apiRequest("POST", "/api/registration", data);
       return response.json();
     },
     onSuccess: () => {

--- a/replit.md
+++ b/replit.md
@@ -41,7 +41,7 @@ Preferred communication style: Simple, everyday language.
 - **Blog Posts table**: Stores blog submissions with approval workflow, categorization, tagging system, and photo upload support (featured images and content images)
 
 ### API Endpoints
-- `POST /api/registrations` - Create new registration
+- `POST /api/registration` - Create new registration
 - `GET /api/registrations` - Retrieve all registrations
 - `POST /api/newsletter` - Subscribe to newsletter
 - `POST /api/testimonials` - Submit testimonial for approval

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,7 +15,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use('/uploads', express.static('uploads'));
   
   // Registration endpoint
-  app.post("/api/registrations", async (req, res) => {
+  app.post("/api/registration", async (req, res) => {
     try {
       const validatedData = insertRegistrationSchema.parse(req.body);
       const registration = await storage.createRegistration(validatedData);


### PR DESCRIPTION
## Summary
- Align registration route to `/api/registration` to match client requests
- Update registration form to post to the new endpoint
- Refresh documentation for the adjusted API path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6892ce4e4e088324ac8151b16601a3a6