### PR TITLE
feat: allow cross-origin API requests

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,7 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 
+const API_BASE = import.meta.env.VITE_API_URL || "";
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
@@ -12,7 +14,8 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const fullUrl = url.startsWith("http") ? url : `${API_BASE}${url}`;
+  const res = await fetch(fullUrl, {
     method,
     headers: data ? { "Content-Type": "application/json" } : {},
     body: data ? JSON.stringify(data) : undefined,
@@ -27,11 +30,13 @@ type UnauthorizedBehavior = "returnNull" | "throw";
 export const getQueryFn: <T>(options: {
   on401: UnauthorizedBehavior;
 }) => QueryFunction<T> =
-  ({ on401: unauthorizedBehavior }) =>
-  async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
-      credentials: "include",
-    });
+    ({ on401: unauthorizedBehavior }) =>
+    async ({ queryKey }) => {
+      const path = queryKey.join("/") as string;
+      const fullUrl = path.startsWith("http") ? path : `${API_BASE}${path}`;
+      const res = await fetch(fullUrl, {
+        credentials: "include",
+      });
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {
       return null;

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,19 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
+
+const allowedOrigin = process.env.CLIENT_ORIGIN || "http://localhost:5173";
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", allowedOrigin);
+  res.header("Access-Control-Allow-Credentials", "true");
+  res.header("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
+  res.header("Access-Control-Allow-Headers", "Content-Type");
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 


### PR DESCRIPTION
## Summary
- prefix frontend API requests with `VITE_API_URL`
- expose simple CORS headers on backend to allow calls from Vercel frontend

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` *(hangs; interrupted)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892d67c4cc48324a13378c86552d4cb