### PR TITLE
Switch team & project cards to blue and expand project details

### DIFF
--- a/client/src/components/floating-projects-section.tsx
+++ b/client/src/components/floating-projects-section.tsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { Code, BarChart, Globe, Github, Play } from "lucide-react";
 
 const projectsData = [
@@ -9,7 +8,7 @@ const projectsData = [
     id: "python-automation",
     title: "Python Automation Projects",
     description: "Real-world automation scripts and applications",
-    color: "from-green-500 to-green-700",
+    color: "from-blue-500 to-blue-700",
     icon: Code,
     projects: [
       {
@@ -135,11 +134,9 @@ const projects = projectsData.flatMap(category =>
 );
 
 export default function FloatingProjectsSection() {
-  const [expandedProject, setExpandedProject] = useState<string>(projects[0].id);
-
   const getDifficultyColor = (difficulty: string) => {
     switch (difficulty) {
-      case "Beginner": return "bg-green-100 text-green-800";
+      case "Beginner": return "bg-blue-100 text-blue-800";
       case "Intermediate": return "bg-yellow-100 text-yellow-800";
       case "Advanced": return "bg-red-100 text-red-800";
       default: return "bg-gray-100 text-gray-800";
@@ -155,32 +152,25 @@ export default function FloatingProjectsSection() {
 
           <div className="grid md:grid-cols-2 gap-8 max-w-6xl mx-auto">
             {projects.map((project, index) => {
-              const isExpanded = expandedProject === project.id;
-                  
-                  return (
+              return (
                     <motion.div
                       key={project.id}
                       initial={{ opacity: 0, y: 50 }}
-                      animate={{ 
-                        opacity: 1, 
+                      animate={{
+                        opacity: 1,
                         y: 0,
-                        scale: isExpanded ? 1.05 : 1,
-                        zIndex: isExpanded ? 10 : 1
+                        scale: 1.05,
+                        zIndex: 10
                       }}
-                      transition={{ 
+                      transition={{
                         duration: 0.3,
                         delay: index * 0.1,
                         scale: { duration: 0.2 }
                       }}
-                      className={`relative ${isExpanded ? 'z-10' : 'z-0'}`}
+                      className="relative z-10"
                     >
-                      <Card 
-                        className={`cursor-pointer transition-all duration-300 overflow-hidden ${
-                          isExpanded 
-                            ? 'shadow-2xl ring-4 ring-blue-200 transform' 
-                            : 'shadow-lg hover:shadow-xl'
-                        }`}
-                        onClick={() => setExpandedProject(isExpanded ? '' : project.id)}
+                      <Card
+                        className="transition-all duration-300 overflow-hidden shadow-2xl ring-4 ring-blue-200 transform"
                       >
                         <CardContent className="p-0">
                           {/* Card Header */}
@@ -204,80 +194,66 @@ export default function FloatingProjectsSection() {
 
                           {/* Card Content */}
                           <div className="p-6">
-                            <AnimatePresence>
-                              {isExpanded ? (
-                                <motion.div
-                                  initial={{ opacity: 0, height: 0 }}
-                                  animate={{ opacity: 1, height: "auto" }}
-                                  exit={{ opacity: 0, height: 0 }}
-                                  transition={{ duration: 0.3 }}
-                                  className="space-y-4"
-                                >
-                                  <div>
-                                    <h5 className="font-semibold text-gray-900 mb-3">Key Features:</h5>
-                                    <ul className="space-y-2">
-                                      {project.features.map((feature, featureIndex) => (
-                                        <motion.li 
-                                          key={featureIndex}
-                                          initial={{ opacity: 0, x: -10 }}
-                                          animate={{ opacity: 1, x: 0 }}
-                                          transition={{ delay: featureIndex * 0.1 }}
-                                          className="flex items-start text-gray-600"
-                                        >
-                                          <div className="w-2 h-2 bg-blue-500 rounded-full mt-2 mr-3 flex-shrink-0" />
-                                          {feature}
-                                        </motion.li>
-                                      ))}
-                                    </ul>
-                                  </div>
+                            <motion.div
+                              initial={{ opacity: 0, height: 0 }}
+                              animate={{ opacity: 1, height: "auto" }}
+                              transition={{ duration: 0.3 }}
+                              className="space-y-4"
+                            >
+                              <div>
+                                <h5 className="font-semibold text-gray-900 mb-3">Key Features:</h5>
+                                <ul className="space-y-2">
+                                  {project.features.map((feature, featureIndex) => (
+                                    <motion.li
+                                      key={featureIndex}
+                                      initial={{ opacity: 0, x: -10 }}
+                                      animate={{ opacity: 1, x: 0 }}
+                                      transition={{ delay: featureIndex * 0.1 }}
+                                      className="flex items-start text-gray-600"
+                                    >
+                                      <div className="w-2 h-2 bg-blue-500 rounded-full mt-2 mr-3 flex-shrink-0" />
+                                      {feature}
+                                    </motion.li>
+                                  ))}
+                                </ul>
+                              </div>
 
-                                  <div className="flex flex-wrap gap-2">
-                                    <span className="text-sm font-medium text-gray-700">Tech Stack:</span>
-                                    {project.tech.map((tech) => (
-                                      <span key={tech} className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded-full">
-                                        {tech}
-                                      </span>
-                                    ))}
-                                  </div>
+                              <div className="flex flex-wrap gap-2">
+                                <span className="text-sm font-medium text-gray-700">Tech Stack:</span>
+                                {project.tech.map((tech) => (
+                                  <span key={tech} className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded-full">
+                                    {tech}
+                                  </span>
+                                ))}
+                              </div>
 
-                                  <div className="pt-4 border-t border-gray-200">
-                                    <div className="grid grid-cols-2 gap-2">
-                                      <Button 
-                                        size="sm"
-                                        className={`bg-gradient-to-r ${project.color} hover:opacity-90`}
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          // Would link to actual demo
-                                        }}
-                                      >
-                                        <Play className="w-4 h-4 mr-2" />
-                                        View Demo
-                                      </Button>
-                                      <Button 
-                                        size="sm"
-                                        variant="outline"
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          // Would link to actual code
-                                        }}
-                                      >
-                                        <Github className="w-4 h-4 mr-2" />
-                                        View Code
-                                      </Button>
-                                    </div>
-                                  </div>
-                                </motion.div>
-                              ) : (
-                                <motion.div
-                                  initial={{ opacity: 0 }}
-                                  animate={{ opacity: 1 }}
-                                  className="text-center py-4"
-                                >
-                                  <p className="text-gray-500 text-sm mb-4">Click to explore this project</p>
-                                  <div className="text-2xl">🚀</div>
-                                </motion.div>
-                              )}
-                            </AnimatePresence>
+                              <div className="pt-4 border-t border-gray-200">
+                                <div className="grid grid-cols-2 gap-2">
+                                  <Button
+                                    size="sm"
+                                    className={`bg-gradient-to-r ${project.color} hover:opacity-90`}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      // Would link to actual demo
+                                    }}
+                                  >
+                                    <Play className="w-4 h-4 mr-2" />
+                                    View Demo
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      // Would link to actual code
+                                    }}
+                                  >
+                                    <Github className="w-4 h-4 mr-2" />
+                                    View Code
+                                  </Button>
+                                </div>
+                              </div>
+                            </motion.div>
                           </div>
                         </CardContent>
                       </Card>

--- a/client/src/components/floating-team-section.tsx
+++ b/client/src/components/floating-team-section.tsx
@@ -66,7 +66,7 @@ const teamData = [
     id: "trainers",
     title: "Training Team",
     description: "Expert instructors with industry experience",
-    color: "from-green-500 to-green-700",
+    color: "from-blue-500 to-blue-700",
     icon: GraduationCap,
     members: [
       {


### PR DESCRIPTION
## Summary
- Update training team card colors to use blue gradient
- Default all project cards to expanded layout and shift beginner badges to blue

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6893472ec45483248ed403bf39cf6f5e