### PR TITLE
Add trainer card for Males Lambe Prosperous

### DIFF
--- a/client/src/components/floating-team-section.tsx
+++ b/client/src/components/floating-team-section.tsx
@@ -90,6 +90,12 @@ const teamData = [
           facebook: "https://facebook.com/yembi.desmond",
           email: "yembi.desmond@ubatechcamp.com"
         }
+      },
+      {
+        name: "Males Lambe Prosperous",
+        role: "Computer Networking Trainer",
+        description: "Electrical | Network Engineer",
+        image: ""
       }
     ]
   },
@@ -245,7 +251,7 @@ export default function FloatingTeamSection() {
                           </h4>
                           <p className="text-blue-600 font-medium mb-2">{member.role}</p>
                           <p className="text-gray-600 text-sm mb-2">{member.description}</p>
-                          {member.subtitle && (
+                          {"subtitle" in member && member.subtitle && (
                             <p className="text-xs text-gray-500 mb-2">{member.subtitle}</p>
                           )}
                         </div>

--- a/client/src/components/team-section.tsx
+++ b/client/src/components/team-section.tsx
@@ -65,6 +65,12 @@ const trainers = [
       facebook: "https://facebook.com/yembi.desmond",
       email: "yembi.desmond@ubatechcamp.com"
     }
+  },
+  {
+    name: "Males Lambe Prosperous",
+    role: "Computer Networking Trainer",
+    description: "Electrical | Network Engineer",
+    image: ""
   }
 ];
 


### PR DESCRIPTION
## Summary
- add Males Lambe Prosperous to Training Team listings
- guard subtitle rendering against missing property

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6895b602479c8324b2338225bda2e0a2