### PR TITLE
Add base path configuration to Vite

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 export default defineConfig({
   plugins: [react()],
+  base: "./",
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
## Summary
- configure Vite to use a relative base path for static assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'vite/bin/vite.js')*

------
https://chatgpt.com/codex/tasks/task_e_689af4c2b5508324acdfa47a3efdb5b8