### PR TITLE
fix server vite config paths and remove git artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules
 dist
 server/dist
+# Git metadata
+COMMIT_EDITMSG
+ORIG_HEAD
+FETCH_HEAD
+HEAD
+MERGE_*
+REBASE_*

--- a/server/COMMIT_EDITMSG
+++ b/server/COMMIT_EDITMSG
@@ -1,1 +1,0 @@
-Remove unwanted files and add new image

--- a/server/HEAD
+++ b/server/HEAD
@@ -1,1 +1,0 @@
-ref: refs/heads/main

--- a/server/ORIG_HEAD
+++ b/server/ORIG_HEAD
@@ -1,1 +1,0 @@
-0af60df7602fe1ffce52aff24e59e3e15b74fd2d

--- a/server/vite.config.ts
+++ b/server/vite.config.ts
@@ -16,12 +16,12 @@ export default defineConfig({
   plugins,
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "client", "src"),
-      "@shared": path.resolve(__dirname, "shared"),
-      "@assets": path.resolve(__dirname, "attached_assets"),
+      "@": path.resolve(__dirname, "..", "client", "src"),
+      "@shared": path.resolve(__dirname, "..", "shared"),
+      "@assets": path.resolve(__dirname, "..", "attached_assets"),
     },
   },
-  root: path.resolve(__dirname, "client"),
+  root: path.resolve(__dirname, "..", "client"),
   build: {
     outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+import viteConfig from "./vite.config";
 import { nanoid } from "nanoid";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- fix vite config import path
- update server vite config to point to actual client and shared directories
- ignore git metadata files and remove stray artifacts

## Testing
- `node node_modules/vite/bin/vite.js build --config server/vite.config.ts` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_689afeeb3e7c832499cbb33f5b003321